### PR TITLE
Detect bad github key in curricula repos

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,14 @@ then
     git config --global user.name "CircleCI"
     git config --global user.email "circleci@thinkful.com"
     git commit -m "automatic commit of uuids after pushing to master [CI skip]"
-    git push origin master --force
+    PUSH_MASTER_OUTPUT=$(git push origin master --force 2>&1)
+    if [[ $PUSH_MASTER_OUTPUT =~ "ERROR" ]]
+    then
+      echo $PUSH_MASTER_OUTPUT
+      echo "Aborting, error pushing to GitHub. This curriculum a read+write key in CI."
+      exit 1
+    fi
+
     git checkout preview --force
     git merge --no-ff master -m="preview < master [CI skip]"
     git push origin preview --force

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,7 +29,7 @@ then
     if [[ $PUSH_MASTER_OUTPUT =~ "ERROR" ]]
     then
       echo $PUSH_MASTER_OUTPUT
-      echo "Aborting, error pushing to GitHub. This curriculum a read+write key in CI."
+      echo "Aborting, error pushing to GitHub. This curriculum needs a read+write key in CI."
       exit 1
     fi
 


### PR DESCRIPTION
Example of a build that should break: https://circleci.com/gh/Thinkful-Ed/learning-with-thinkful-for-core-v1/29

The curriculum build process pushes UUIDs back into the structure.xml in master. If this push fails silently, as it has so far, we end up with UUID's in production that get re-generated the next time the curriculum is pushed, and (I'm pretty sure) resets progress for everyone on those.

Related to https://github.com/Thinkful/Thinkful/issues/541